### PR TITLE
Add extra metadata to the manifest Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "rac"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"
+homepage = "https://github.com/toradex/torizon-rac"
+description = "Remote access client for Torizon"
+repository = "git://github.com/toradex/torizon-rac.git"
+license = "Apache-2.0"
+license-file = "LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This commit adds some extra metadata to allow to use the subcommand `cargo bitbake`, this because it is necessary for the Yocto recipe used in TorizonCore.
Without this commit `cargo bitbake` fails by asking you to add the missing fields in the manifest.